### PR TITLE
Don't strip slashes from fullPath

### DIFF
--- a/src/lib/DAV/Entry.js
+++ b/src/lib/DAV/Entry.js
@@ -34,7 +34,7 @@ export default class Entry extends EventObject {
     super();
 
     this.#directory = directory;
-    this.#fullPath = joinPath(fullPath);
+    this.#fullPath = fullPath;
     [this.#path, this.#name] = this.getFilename();
     this.#title = title;
     this.#modified = modified;


### PR DESCRIPTION
The lack of a fitting slash causes strict servers like nginx to refuse
deletion of a collection (resulting in a "409 Conflict" error, which
strictly speaking should probably be a 404).

Keeping fullPath as it is on received propfind entries should generally
be the right thing, as the server (which is the authority of its URIs)
can be expected to provide them in the very form it later expects them
used. (And for legitimate concatenation as in the creation of names for
to-be-uploaded files, the slash will be stripped when the paths are
joint anyway).

---

(No issue was created explicitly for this; if you prefer to have one for better tracking, let me know and I'll open one up about folders being unremovable on nginx)