### PR TITLE
WIP Examples: header.html use raw html tags instead of bookmarklet

### DIFF
--- a/examples/apache-directory-list-local/header.html
+++ b/examples/apache-directory-list-local/header.html
@@ -1,2 +1,2 @@
-<script type="text/javascript">["/webdav-js/assets/css/style-min.css","/webdav-js/src/webdav-min.js"].forEach((function(e,s){/css$/.test(e)?((s=document.createElement("link")).href=e,s.rel="stylesheet"):(s=document.createElement("script")).src=e,document.head.appendChild(s)}));
-</script><!--
+<link href="/webdav-js/assets/css/style-min.css" rel="stylesheet"/>
+<script src="/webdav-js/src/webdav-min.js"></script>

--- a/examples/apache-directory-list/README.md
+++ b/examples/apache-directory-list/README.md
@@ -1,6 +1,6 @@
 # Apache Directory List Example
 
-_Note_: this uses web-based assets for easy set up.
+_Note_: this uses web-based assets for easy set up. It loads the script from CDN.
 
 To utilise this apache directory list replacement, you'll need to have your own
 server set up and configured with WevDAV (hopefully that's a given!).

--- a/examples/apache-directory-list/header.html
+++ b/examples/apache-directory-list/header.html
@@ -1,2 +1,2 @@
-<script type="text/javascript">["https://cdn.jsdelivr.net/gh/dom111/webdav-js/assets/css/style-min.css","https://cdn.jsdelivr.net/gh/dom111/webdav-js/src/webdav-min.js"].forEach((function(e,s){/css$/.test(e)?((s=document.createElement("link")).href=e,s.rel="stylesheet"):(s=document.createElement("script")).src=e,document.head.appendChild(s)}));
-</script><!--
+<link href="https://cdn.jsdelivr.net/gh/dom111/webdav-js/assets/css/style-min.css" rel="stylesheet"/>
+<script src="https://cdn.jsdelivr.net/gh/dom111/webdav-js/src/webdav-min.js"></script>


### PR DESCRIPTION
And I didn't tested the header.html with Apache but I just put an `index.html` file into doc root and now it's  shown fine when uses the bookmarklet loader.
But when I used the plain html tags I got an error in console:
```
Uncaught TypeError: Invalid container element: 'null'.
    n https://cdn.jsdelivr.net/gh/dom111/webdav-js/src/webdav-min.js:1
```
I have no idea why it doesn't works. Could you investigate it?
I also tried to use `webdav.js` instead of `webdav-min.js` but it doesn't works at all because has imports.

And I still don't get why the comment added in the end.
